### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "run = \"run = \"\"echo hello word\""

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the TolstoyMustReads project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/<github username>/tolstoy_must_reads/blob/master/CODE_OF_CONDUCT.md).
+
+[![Run on Repl.it](https://repl.it/badge/github/cantstopcoding/tolstoy_must_reads)](https://repl.it/github/cantstopcoding/tolstoy_must_reads)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).